### PR TITLE
JS: Use more realistic dummy field markup.

### DIFF
--- a/package/src/method-element.js
+++ b/package/src/method-element.js
@@ -76,6 +76,8 @@ class MethodElement {
     const $textField = $(`
       <div class="form-item form-type-stripe-payment-field">
         <input type="text" class="default" />
+      </div>
+      <div class="form-item form-type-stripe-payment-field">
         <input type="text" class="error invalid" />
       </div>`
     ).hide().appendTo(this.$element)


### PR DESCRIPTION
Usually in Drupal there are no two inputs next to each other, both would have a wrapper of their own. Our dummy fields should do the same – otherwise the copied styles might not be correct.