### PR TITLE
Get mandate info for one-off payments.

### DIFF
--- a/src/SepaController.php
+++ b/src/SepaController.php
@@ -60,20 +60,20 @@ class SepaController extends StripeController {
       $expand[] = 'mandate';
       $expand[] = 'payment_method';
       $intent = parent::fetchIntent($payment, $api, $expand);
-      $payment->stripe_sepa = [
-        'mandate_reference' => $intent['mandate']['payment_method_details']['sepa_debit']['reference'],
-        'last4' => $intent['payment_method']['sepa_debit']['last4'],
-      ];
+      $mandate = $intent['mandate'];
+      $details = $intent['payment_method']['sepa_debit'];
     }
     else {
+      // At the time of writing this neither PaymentIntents nor PaymentMethods
+      // include the mandate data. So we need this detour via charges.
       $intent = parent::fetchIntent($payment, $api, $expand);
       $details = $intent['charges']['data'][0]['payment_method_details']['sepa_debit'];
       $mandate = $api->retrieveMandate($details['mandate']);
-      $payment->stripe_sepa = [
-        'mandate_reference' => $mandate['payment_method_details']['sepa_debit']['reference'],
-        'last4' => $details['last4'],
-      ];
     }
+    $payment->stripe_sepa = [
+      'mandate_reference' => $mandate['payment_method_details']['sepa_debit']['reference'],
+      'last4' => $details['last4'],
+    ];
     return $intent;
   }
 

--- a/src/SepaController.php
+++ b/src/SepaController.php
@@ -55,13 +55,18 @@ class SepaController extends StripeController {
    * Load the intent object and populate the $payment object accordingly.
    */
   protected function fetchIntent(\Payment $payment, Api $api, array $expand = []) {
-    $expand[] = 'mandate';
-    $expand[] = 'payment_method';
+    $recurring = substr($payment->method_data['stripe_id'], 0, 5) == 'seti_';
+    if ($recurring) {
+      $expand[] = 'mandate';
+      $expand[] = 'payment_method';
+    }
     $intent = parent::fetchIntent($payment, $api, $expand);
-    $payment->stripe_sepa = [
-      'mandate_reference' => $intent['mandate']['payment_method_details']['sepa_debit']['reference'],
-      'last4' => $intent['payment_method']['sepa_debit']['last4'],
-    ];
+    if ($recurring) {
+      $payment->stripe_sepa = [
+        'mandate_reference' => $intent['mandate']['payment_method_details']['sepa_debit']['reference'],
+        'last4' => $intent['payment_method']['sepa_debit']['last4'],
+      ];
+    }
     return $intent;
   }
 

--- a/src/SepaController.php
+++ b/src/SepaController.php
@@ -59,12 +59,19 @@ class SepaController extends StripeController {
     if ($recurring) {
       $expand[] = 'mandate';
       $expand[] = 'payment_method';
-    }
-    $intent = parent::fetchIntent($payment, $api, $expand);
-    if ($recurring) {
+      $intent = parent::fetchIntent($payment, $api, $expand);
       $payment->stripe_sepa = [
         'mandate_reference' => $intent['mandate']['payment_method_details']['sepa_debit']['reference'],
         'last4' => $intent['payment_method']['sepa_debit']['last4'],
+      ];
+    }
+    else {
+      $intent = parent::fetchIntent($payment, $api, $expand);
+      $details = $intent['charges']['data'][0]['payment_method_details']['sepa_debit'];
+      $mandate = $api->retrieveMandate($details['mandate']);
+      $payment->stripe_sepa = [
+        'mandate_reference' => $mandate['payment_method_details']['sepa_debit']['reference'],
+        'last4' => $details['last4'],
       ];
     }
     return $intent;

--- a/tests/SepaControllerTest.php
+++ b/tests/SepaControllerTest.php
@@ -78,20 +78,33 @@ class SepaControllerTest extends DrupalUnitTestCase {
   public function testExecuteOneOff() {
     $method = $this->method;
     $api = $this->createMock(Api::class);
+    $charge['payment_method_details']['sepa_debit'] = [
+      'mandate' => 'mandate_stripemandateid',
+      'last4' => '1234',
+    ];
+    $intent['charges']['data'][] = $charge;
+    $mandate['payment_method_details']['sepa_debit']['reference'] = 'TEST-SEPA-REFERENCE';
     $api->expects($this->once())
       ->method('retrieveIntent')
       ->with($this->equalTo('pi_testpaymentintent'), $this->equalTo([]))
       ->willReturn(PaymentIntent::constructFrom([
         'id' => 'pi_testpaymentintent',
         'object' => 'paymentintent',
-      ]));
+      ] + $intent));
+    $api->expects($this->once())
+      ->method('retrieveMandate')
+      ->with($this->equalTo('mandate_stripemandateid'))
+      ->willReturn(Mandate::constructFrom($mandate));
     $method->api = $api;
     $payment = entity_create('payment', ['method' => $method]);
     $payment->method_data = ['stripe_id' => 'pi_testpaymentintent'];
     $payment->stripe_sepa = NULL;
     $method->controller->execute($payment);
 
-    $this->assertEmpty($payment->stripe_sepa);
+    $this->assertEqual([
+      'mandate_reference' => 'TEST-SEPA-REFERENCE',
+      'last4' => '1234',
+    ], $payment->stripe_sepa);
   }
 
 }

--- a/tests/SepaControllerTest.php
+++ b/tests/SepaControllerTest.php
@@ -6,6 +6,7 @@ use Upal\DrupalUnitTestCase;
 
 use Stripe\Mandate;
 use Stripe\PaymentMethod;
+use Stripe\PaymentIntent;
 use Stripe\SetupIntent;
 
 /**
@@ -55,11 +56,11 @@ class SepaControllerTest extends DrupalUnitTestCase {
       ->method('retrieveIntent')
       ->with($this->equalTo('seti_testsetupintent'), $this->equalTo(['mandate', 'payment_method']))
       ->willReturn(SetupIntent::constructFrom([
-      'id' => 'seti_testsetupintent',
-      'object' => 'setupintent',
-      'mandate' => Mandate::constructFrom($mandate),
-      'payment_method' => PaymentMethod::constructFrom($pm),
-    ]));
+        'id' => 'seti_testsetupintent',
+        'object' => 'setupintent',
+        'mandate' => Mandate::constructFrom($mandate),
+        'payment_method' => PaymentMethod::constructFrom($pm),
+      ]));
     $method->api = $api;
     $payment = entity_create('payment', ['method' => $method]);
     $payment->method_data = ['stripe_id' => 'seti_testsetupintent'];
@@ -69,6 +70,28 @@ class SepaControllerTest extends DrupalUnitTestCase {
       'mandate_reference' => 'TEST-SEPA-REFERENCE',
       'last4' => '1234',
     ], $payment->stripe_sepa);
+  }
+
+  /**
+   * Test that $payment->stripe_sepa is not set for one-off payments.
+   */
+  public function testExecuteOneOff() {
+    $method = $this->method;
+    $api = $this->createMock(Api::class);
+    $api->expects($this->once())
+      ->method('retrieveIntent')
+      ->with($this->equalTo('pi_testpaymentintent'), $this->equalTo([]))
+      ->willReturn(PaymentIntent::constructFrom([
+        'id' => 'pi_testpaymentintent',
+        'object' => 'paymentintent',
+      ]));
+    $method->api = $api;
+    $payment = entity_create('payment', ['method' => $method]);
+    $payment->method_data = ['stripe_id' => 'pi_testpaymentintent'];
+    $payment->stripe_sepa = NULL;
+    $method->controller->execute($payment);
+
+    $this->assertEmpty($payment->stripe_sepa);
   }
 
 }

--- a/tests/TokenIntegrationTest.php
+++ b/tests/TokenIntegrationTest.php
@@ -30,4 +30,17 @@ HTML;
     $this->assertEqual($expected, $result);
   }
 
+  /**
+   * Test replacing [payment:stripe-sepa-mandate-info].
+   */
+  public function testNoMandateInfoWithoutMandate() {
+    $controller = payment_method_controller_load('stripe_payment_sepa');
+    $method = entity_create('payment_method', ['controller' => $controller]);
+    $method->controller_data['creditor_id'] = 'TEST-CREDITOR-ID';
+    $payment = entity_create('payment', ['method' => $method]);
+    $result = token_replace('[payment:stripe-sepa-mandate-info]', ['payment' => $payment], ['clear' => TRUE]);
+    $expected = '';
+    $this->assertEqual($expected, $result);
+  }
+
 }


### PR DESCRIPTION
Setting `?expand=mandate` one payment intent yields a HTTP 400 error.