### PR TITLE
Add setup_future_usage for mixed payments.

### DIFF
--- a/src/Api.php
+++ b/src/Api.php
@@ -83,6 +83,7 @@ class Api {
       return PaymentIntent::create([
         'amount'   => (int) ($one_off->totalAmount(TRUE) * 100),
         'currency' => $payment->currency_code,
+        'setup_future_usage' => $recurring->line_items ? 'off_session' : NULL,
       ] + $settings);
     }
     // SetupIntent: Save card details for later use without initial payment.

--- a/src/CreditCardForm.php
+++ b/src/CreditCardForm.php
@@ -23,9 +23,8 @@ class CreditCardForm extends _CreditCardForm {
    *   The updated form array.
    */
   public function form(array $form, array &$form_state, \Payment $payment) {
-    $stripe_form = new StripeForm();
     $form = parent::form($form, $form_state, $payment);
-    $form = $stripe_form->form($form, $form_state, $payment);
+    $form = StripeForm::form($form, $form_state, $payment);
 
     // Override payment fields.
     $form['credit_card_number'] = [

--- a/src/SepaForm.php
+++ b/src/SepaForm.php
@@ -23,9 +23,8 @@ class SepaForm extends AccountForm {
    *   The updated form array.
    */
   public function form(array $form, array &$form_state, \Payment $payment) {
-    $stripe_form = new StripeForm();
     $form = parent::form($form, $form_state, $payment);
-    $form = $stripe_form->form($form, $form_state, $payment);
+    $form = StripeForm::form($form, $form_state, $payment);
 
     // Override payment fields.
     $form['iban'] = [

--- a/src/StripeForm.php
+++ b/src/StripeForm.php
@@ -2,12 +2,10 @@
 
 namespace Drupal\stripe_payment;
 
-use Drupal\payment_forms\PaymentFormInterface;
-
 /**
  * Stripe form helper class.
  */
-class StripeForm implements PaymentFormInterface {
+abstract class StripeForm {
 
   /**
    * Add form settings for Stripe payments.
@@ -22,7 +20,7 @@ class StripeForm implements PaymentFormInterface {
    * @return array
    *   The updated form array.
    */
-  public function form(array $form, array &$form_state, \Payment $payment) {
+  public static function form(array $form, array &$form_state, \Payment $payment) {
     $method = &$payment->method;
     $customer_data_form = $method->controller->customerDataForm();
 
@@ -68,7 +66,7 @@ class StripeForm implements PaymentFormInterface {
    * @param \Payment $payment
    *   The payment object.
    */
-  public function validate(array $element, array &$form_state, \Payment $payment) {
+  public static function validate(array $element, array &$form_state, \Payment $payment) {
     $values = drupal_array_get_nested_value($form_state['values'], $element['#parents']);
     $payment->method_data['stripe_id'] = $values['stripe_id'];
     $customer_data_form = $payment->method->controller->customerDataForm();


### PR DESCRIPTION
It seems that we can only add subscriptions for a `PaymentIntent` if `setup_future_usage` was set to `off_session`.