### PR TITLE
Draft: add new payment method for Bacs debit

### DIFF
--- a/package/src/method-element.js
+++ b/package/src/method-element.js
@@ -209,6 +209,13 @@ class MethodElement {
       data.payment_method.sepa_debit = this.stripeElements.getElement('iban')
       handler = name === 'setupIntent' ? 'confirmSepaDebitSetup' : 'confirmSepaDebitPayment'
     }
+    else if (this.intent.methods.includes('bacs_debit')) {
+      data.payment_method.bacs_debit = {
+        account_number: this.$element.find('[name$="[account_number]"]').val(),
+        sort_code: this.$element.find('[name$="[sort_code]"]').val()
+      }
+      handler = name === 'setupIntent' ? 'confirmBacsDebitSetup' : 'confirmBacsDebitPayment'
+    }
     else {
       data.payment_method.card = this.stripeElements.getElement('cardNumber')
       handler = name === 'setupIntent' ? 'confirmCardSetup' : 'confirmCardPayment'

--- a/src/BacsController.php
+++ b/src/BacsController.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Drupal\stripe_payment;
+
+/**
+ * Payment method controller for stripe Bacs payments.
+ */
+class BacsController extends StripeController {
+
+  /**
+   * Create a new controller instance.
+   */
+  public function __construct() {
+    $this->title = t('Stripe Bacs');
+    $this->intentSettings = [
+      'payment_method_types' => ['bacs_debit'],
+    ];
+    parent::__construct();
+  }
+
+  /**
+   * Get a payment form.
+   *
+   * @return BacsForm
+   *   A new Bacs form.
+   */
+  public function paymentForm() {
+    return new BacsForm();
+  }
+
+  /**
+   * Get a customer data form.
+   *
+   * @return CustomerDataForm
+   *   A new customer data form.
+   */
+  public function customerDataForm() {
+    return new BacsCustomerDataForm();
+  }
+
+  /**
+   * Load the intent object and populate the $payment object accordingly.
+   */
+  protected function fetchIntent(\Payment $payment, Api $api, array $expand = []) {
+    $recurring = substr($payment->method_data['stripe_id'], 0, 5) == 'seti_';
+    if ($recurring) {
+      $expand[] = 'mandate';
+      $expand[] = 'payment_method';
+      $intent = parent::fetchIntent($payment, $api, $expand);
+      $mandate = $intent['mandate'];
+      $details = $intent['payment_method']['bacs_debit'];
+    }
+    else {
+      // At the time of writing this neither PaymentIntents nor PaymentMethods
+      // include the mandate data. So we need this detour via charges.
+      $intent = parent::fetchIntent($payment, $api, $expand);
+      $details = $intent['charges']['data'][0]['payment_method_details']['bacs_debit'];
+      $mandate = $api->retrieveMandate($details['mandate']);
+    }
+    $payment->stripe_bacs = [
+      'mandate_reference' => $mandate['payment_method_details']['bacs_debit']['reference'],
+      'last4' => $details['last4'],
+    ];
+    return $intent;
+  }
+
+}

--- a/src/BacsControllerRecurrent.php
+++ b/src/BacsControllerRecurrent.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Drupal\stripe_payment;
+
+use Drupal\webform_paymethod_select\PaymentRecurrentController;
+
+/**
+ * Recurrent version of the BacsController.
+ *
+ * This is useful while migrating to the payment_recurrence module.
+ *
+ * @see https://github.com/moreonion/webform_paymethod_select/issues/16
+ */
+class BacsControllerRecurrent extends BacsController implements PaymentRecurrentController {
+
+}

--- a/src/BacsCustomerDataForm.php
+++ b/src/BacsCustomerDataForm.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Drupal\stripe_payment;
+
+/**
+ * Form for customer data that’s used for SEPA payments.
+ */
+class BacsCustomerDataForm extends CustomerDataForm {
+
+  /**
+   * Extend default field input settings.
+   */
+  public function defaultSettings() {
+    $defaults = parent::defaultSettings();
+    // Stripe requires a name and an email address for SEPA payments,
+    // set default to display those fields if not already on the form.
+    $defaults['billing_details']['name'] = [
+      'enabled' => TRUE,
+      'display' => 'ifnotset',
+      'keys' => ['name'],
+      'required' => TRUE,
+      'display_other' => 'ifnotset',
+    ];
+    $defaults['billing_details']['email'] = [
+      'enabled' => TRUE,
+      'display' => 'ifnotset',
+      'keys' => ['email'],
+      'required' => TRUE,
+      'display_other' => 'ifnotset',
+    ];
+    $defaults['billing_details']['address_line1'] = [
+      'enabled' => TRUE,
+      'display' => 'ifnotset',
+      'keys' => ['address_line1', 'street_address'],
+      'required' => TRUE,
+      'display_other' => 'ifnotset',
+    ];
+    $defaults['billing_details']['postcode'] = [
+      'enabled' => TRUE,
+      'display' => 'ifnotset',
+      'keys' => ['postcode', 'zip_code'],
+      'required' => TRUE,
+      'display_other' => 'ifnotset',
+    ];
+    $defaults['billing_details']['city'] = [
+      'enabled' => TRUE,
+      'display' => 'ifnotset',
+      'keys' => ['email'],
+      'required' => TRUE,
+      'display_other' => 'ifnotset',
+    ];
+    $defaults['billing_details']['country'] = [
+      'enabled' => TRUE,
+      'display' => 'ifnotset',
+      'keys' => ['country'],
+      'required' => TRUE,
+      'display_other' => 'ifnotset',
+    ];
+    return $defaults;
+  }
+
+  /**
+   * Extends Stripe fields.
+   */
+  public function fields() {
+    $fields = parent::fields();
+    // Ensure Stripe required fields are required.
+    $fields['billing_details']['name']['#required'] = TRUE;
+    $fields['billing_details']['email']['#required'] = TRUE;
+    return $fields;
+  }
+
+}

--- a/src/BacsForm.php
+++ b/src/BacsForm.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Drupal\stripe_payment;
+
+use Drupal\payment_forms\PaymentFormInterface;
+
+/**
+ * Stripe Bacs form.
+ */
+class BacsForm implements PaymentFormInterface {
+
+  /**
+   * Add form elements for Stripe Bacs payments.
+   *
+   * @param array $form
+   *   The Drupal form array.
+   * @param array $form_state
+   *   The Drupal form_state array.
+   * @param \Payment $payment
+   *   The payment object.
+   *
+   * @return array
+   *   The updated form array.
+   */
+  public function form(array $form, array &$form_state, \Payment $payment) {
+    $form = StripeForm::form($form, $form_state, $payment);
+    $form['sort_code'] = array(
+      '#type' => 'textfield',
+      '#title' => t('Sort Code'),
+      '#maxlength' => 8,
+      '#cleave' => [
+        'blocks' => [2, 2, 2],
+        'delimiter' => '-',
+        'numericOnly' => TRUE,
+      ],
+    );
+    $form['account_number'] = array(
+      '#type' => 'textfield',
+      '#title' => t('Account Number'),
+      '#maxlength' => 10,
+      '#cleave' => [
+        'blocks' => [10],
+        'numericOnly' => TRUE,
+      ],
+    );
+    return $form;
+  }
+
+  /**
+   * Store relevant values in the payment’s method_data.
+   *
+   * @param array $element
+   *   The Drupal elements array.
+   * @param array $form_state
+   *   The Drupal form_state array.
+   * @param \Payment $payment
+   *   The payment object.
+   */
+  public function validate(array $element, array &$form_state, \Payment $payment) {
+    StripeForm::validate($element, $form_state, $payment);
+  }
+
+}

--- a/stripe_payment.module
+++ b/stripe_payment.module
@@ -6,6 +6,8 @@
  */
 
 use Drupal\stripe_payment\Api;
+use Drupal\stripe_payment\BacsController;
+use Drupal\stripe_payment\BacsControllerRecurrent;
 use Drupal\stripe_payment\CreditCardController;
 use Drupal\stripe_payment\CreditCardControllerRecurrent;
 use Drupal\stripe_payment\SepaController;
@@ -84,6 +86,7 @@ function stripe_payment_theme() {
 function stripe_payment_payment_method_controller_info() {
   $recurrent = module_exists('webform_paymethod_select') && interface_exists(PaymentRecurrentController::class, TRUE);
   return [
+    'stripe_payment_bacs' => $recurrent ? BacsControllerRecurrent::class : BacsController::class,
     'stripe_payment_credit_card' => $recurrent ? CreditCardControllerRecurrent::class : CreditCardController::class,
     'stripe_payment_sepa' => $recurrent ? SepaControllerRecurrent::class : SepaController::class,
   ];


### PR DESCRIPTION
Incomplete draft implementation for bacs debit.

For the current code, Stripe responds with "Your account is not configured to allow passing mandate_data directly when confirming PaymentIntents for Bacs Direct Debits." Not quite sure what that means. Maybe a customer (with the bacs_debit method) needs to be created *before* attaching it to a setup intent?

Edit: The error has changed to "Your account is not configured to directly use SetupIntents to create Mandates for Bacs Direct Debits." when adding "bacs_debit" as payment method type to the setup intent. There is no way to configure anything for Bacs DD in the Stripe UI (except upgrading to a payed version to show your business name on bank statements) → requires a conversation with support (bacs-debits@stripe.com).

Edit: The error occurs when `bacs_debit` is in the list of 'payment_method_types' for a SetupIntent.

Note: `confirmBacsDebitPayment()` does not exists, can only be used with setup intents.