### PR TITLE
Provide "name" for clientside validation

### DIFF
--- a/src/CreditCardForm.php
+++ b/src/CreditCardForm.php
@@ -30,7 +30,6 @@ class CreditCardForm extends _CreditCardForm {
     $form['credit_card_number'] = [
       '#type' => 'stripe_payment_field',
       '#field_name' => 'cardNumber',
-      '#parents' => ['cc-number'],
       '#attributes' => [
         'class' => ['cc-number'],
       ],
@@ -38,7 +37,6 @@ class CreditCardForm extends _CreditCardForm {
     $form['secure_code'] = [
       '#type' => 'stripe_payment_field',
       '#field_name' => 'cardCvc',
-      '#parents' => ['cc-cvv'],
       '#attributes' => [
         'class' => ['cc-cvv'],
       ],
@@ -46,7 +44,6 @@ class CreditCardForm extends _CreditCardForm {
     $form['expiry_date'] = [
       '#type' => 'stripe_payment_field',
       '#field_name' => 'cardExpiry',
-      '#parents' => ['cc-expiry'],
       '#attributes' => [
         'class' => ['cc-expiry'],
       ],

--- a/src/SepaForm.php
+++ b/src/SepaForm.php
@@ -30,7 +30,6 @@ class SepaForm extends AccountForm {
     $form['iban'] = [
       '#type' => 'stripe_payment_field',
       '#field_name' => 'iban',
-      '#parents' => ['iban'],
       '#attributes' => [
         'class' => ['iban'],
       ],

--- a/stripe_payment.theme.inc
+++ b/stripe_payment.theme.inc
@@ -14,9 +14,13 @@
  */
 function template_process_stripe_payment_field(&$vars) {
   $vars['attributes'] = $vars['element']['#attributes'] ?? [];
+  $parents = $vars['element']['#parents'];
+  $name = array_shift($parents);
+  $name .= $parents ? '[' . implode('][', $parents) . ']' : '';
   $vars['attributes'] += [
     'id' => $vars['element']['#id'] ?? drupal_html_id('stripe-payment-field'),
     'data-stripe-element' => $vars['element']['#field_name'],
+    'name' => $name,
   ];
   $vars['attributes']['class'][] = 'stripe-payment-field-iframe-wrapper';
   $vars['attributes']['class'][] = 'text-input';


### PR DESCRIPTION
A name attribute is required by clientside validation to identify the (fake) field. This re-adds it although not being valid html.